### PR TITLE
docs(fix): add required v2 to theme module url

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This theme uses the "Tachyons" CSS library. This will allow you to manipulate th
 2. Add the theme's repo to your `config.toml`:
 
    ```toml
-   theme = ["github.com/theNewDynamic/gohugo-theme-ananke"]
+   theme = ["github.com/theNewDynamic/gohugo-theme-ananke/v2"]
    ```
 
 ### As Git Submodule


### PR DESCRIPTION
Closes #791

Since it is required by go to use /v2 for post 2.0 versions in the path this is required to get module method of using the theme to work.

